### PR TITLE
Add Java versions of option classes

### DIFF
--- a/java/com/koalawiki/options/DocumentOptions.java
+++ b/java/com/koalawiki/options/DocumentOptions.java
@@ -1,0 +1,69 @@
+package com.koalawiki.options;
+
+/**
+ * 文档相关配置
+ */
+public class DocumentOptions {
+    public static final String NAME = "Document";
+
+    /** 是否启用增量更新 */
+    public static boolean enableIncrementalUpdate = true;
+
+    /** 排除的文件 */
+    public static String[] excludedFiles = new String[0];
+
+    /** 排除的文件夹 */
+    public static String[] excludedFolders = new String[0];
+
+    /** 是否启用智能过滤 */
+    public static boolean enableSmartFilter = true;
+
+    /** 是否启用代码依赖分析 */
+    public static boolean enableCodeDependencyAnalysis = false;
+
+    /** 是否启用仓库功能提示任务 */
+    public static boolean enableWarehouseFunctionPromptTask = true;
+
+    /** 是否启用仓库描述任务 */
+    public static boolean enableWarehouseDescriptionTask = true;
+
+    /** 是否启用文件提交 */
+    public static boolean enableFileCommit = true;
+
+    public static void initConfig(ConfigProvider configuration) {
+        configuration.getSection(NAME, DocumentOptions.class); // 读取但不赋值，保留静态默认
+
+        Boolean fileCommit = configuration.getBoolean("ENABLE_FILE_COMMIT");
+        if (fileCommit != null) {
+            enableFileCommit = fileCommit;
+        }
+
+        String incr = configuration.getString("ENABLE_INCREMENTAL_UPDATE");
+        if (incr != null) {
+            enableIncrementalUpdate = Boolean.parseBoolean(incr);
+        }
+
+        String dep = configuration.getString("ENABLE_CODED_DEPENDENCY_ANALYSIS");
+        if (dep != null) {
+            enableCodeDependencyAnalysis = Boolean.parseBoolean(dep);
+        }
+
+        String funcTask = configuration.getString("ENABLE_WAREHOUSE_FUNCTION_PROMPT_TASK");
+        if (funcTask != null) {
+            enableWarehouseFunctionPromptTask = Boolean.parseBoolean(funcTask);
+        }
+
+        String descTask = configuration.getString("ENABLE_WAREHOUSE_DESCRIPTION_TASK");
+        if (descTask != null) {
+            enableWarehouseDescriptionTask = Boolean.parseBoolean(descTask);
+        }
+    }
+
+    public interface ConfigProvider {
+        <T> T getSection(String name, Class<T> clazz);
+
+        String getString(String key);
+
+        Boolean getBoolean(String key);
+    }
+}

--- a/java/com/koalawiki/options/GithubOptions.java
+++ b/java/com/koalawiki/options/GithubOptions.java
@@ -1,0 +1,32 @@
+package com.koalawiki.options;
+
+/**
+ * Github 配置
+ */
+public class GithubOptions {
+    private static String clientId;
+    private static String clientSecret;
+    private static String token;
+
+    public static String getClientId() {
+        return clientId;
+    }
+
+    public static String getClientSecret() {
+        return clientSecret;
+    }
+
+    public static String getToken() {
+        return token;
+    }
+
+    public static void initConfig(ConfigProvider configuration) {
+        clientId = configuration.get("Github:ClientId", "GITHUB_CLIENT_ID");
+        clientSecret = configuration.get("Github:ClientSecret", "GITHUB_CLIENT_SECRET");
+        token = configuration.get("Github:Token", "GITHUB_TOKEN");
+    }
+
+    public interface ConfigProvider {
+        String get(String... keys);
+    }
+}

--- a/java/com/koalawiki/options/JwtOptions.java
+++ b/java/com/koalawiki/options/JwtOptions.java
@@ -1,0 +1,111 @@
+package com.koalawiki.options;
+
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.Objects;
+
+/**
+ * JWT配置选项
+ */
+public class JwtOptions {
+    /**
+     * 配置名称
+     */
+    public static final String NAME = "Jwt";
+
+    /** 密钥 */
+    private String secret = "";
+
+    /** 颁发者 */
+    private String issuer = "";
+
+    /** 接收者 */
+    private String audience = "";
+
+    /** 过期时间（分钟） */
+    private int expireMinutes = 60 * 24; // 默认1天
+
+    /** 刷新令牌过期时间（分钟） */
+    private int refreshExpireMinutes = 60 * 24 * 7; // 默认7天
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public void setAudience(String audience) {
+        this.audience = audience;
+    }
+
+    public int getExpireMinutes() {
+        return expireMinutes;
+    }
+
+    public void setExpireMinutes(int expireMinutes) {
+        this.expireMinutes = expireMinutes;
+    }
+
+    public int getRefreshExpireMinutes() {
+        return refreshExpireMinutes;
+    }
+
+    public void setRefreshExpireMinutes(int refreshExpireMinutes) {
+        this.refreshExpireMinutes = refreshExpireMinutes;
+    }
+
+    /**
+     * 获取签名凭证
+     */
+    public SecretKey getSymmetricSecurityKey() {
+        return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    /**
+     * 初始化配置
+     */
+    public static JwtOptions initConfig(ConfigProvider configuration) {
+        JwtOptions options = configuration.getSection(NAME, JwtOptions.class);
+        if (options == null) {
+            options = new JwtOptions();
+        }
+
+        if (options.secret == null || options.secret.isEmpty()) {
+            options.secret = UUID.randomUUID().toString().replace("-", "") +
+                    UUID.randomUUID().toString().replace("-", "");
+        }
+
+        if (options.issuer == null || options.issuer.isEmpty()) {
+            options.issuer = "KoalaWiki";
+        }
+
+        if (options.audience == null || options.audience.isEmpty()) {
+            options.audience = "KoalaWiki";
+        }
+
+        return options;
+    }
+
+    /**
+     * 简单的配置提供者接口，便于示例
+     */
+    public interface ConfigProvider {
+        <T> T getSection(String name, Class<T> clazz);
+    }
+}

--- a/java/com/koalawiki/options/OpenAIOptions.java
+++ b/java/com/koalawiki/options/OpenAIOptions.java
@@ -1,0 +1,77 @@
+package com.koalawiki.options;
+
+/**
+ * OpenAI 相关配置
+ */
+public class OpenAIOptions {
+    /** ChatGPT模型 */
+    public static String chatModel = "";
+
+    /** 分析模型 */
+    public static String analysisModel = "";
+
+    /** ChatGPT API密钥 */
+    public static String chatApiKey = "";
+
+    /** API地址 */
+    public static String endpoint = "";
+
+    /** 模型提供商 */
+    public static String modelProvider = "";
+
+    /** 最大文件限制 */
+    public static int maxFileLimit = 10;
+
+    /** 深度研究模型 */
+    public static String deepResearchModel = "";
+
+    /** 嵌入模型 */
+    public static String embeddingsModel = "";
+
+    public static void initConfig(ConfigProvider configuration) throws Exception {
+        chatModel = trim(configuration.get("CHAT_MODEL", "ChatModel"));
+        analysisModel = trim(configuration.get("ANALYSIS_MODEL", "AnalysisModel"));
+        chatApiKey = trim(configuration.get("CHAT_API_KEY", "ChatApiKey"));
+        endpoint = trim(configuration.get("ENDPOINT", "Endpoint"));
+        modelProvider = trim(configuration.get("MODEL_PROVIDER", "ModelProvider"));
+        deepResearchModel = trim(configuration.get("DEEP_RESEARCH_MODEL", "DeepResearchModel"));
+
+        String max = configuration.get("MAX_FILE_LIMIT");
+        if (max != null && !max.isEmpty()) {
+            try {
+                maxFileLimit = Integer.parseInt(max);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        embeddingsModel = trim(configuration.get("EMBEDDINGS_MODEL", "EmbeddingsModel"));
+
+        if (modelProvider == null || modelProvider.isEmpty()) {
+            modelProvider = "OpenAI";
+        }
+
+        if (chatModel == null || chatModel.isEmpty()) {
+            throw new Exception("ChatModel is empty");
+        }
+        if (chatApiKey == null || chatApiKey.isEmpty()) {
+            throw new Exception("ChatApiKey is empty");
+        }
+        if (endpoint == null || endpoint.isEmpty()) {
+            throw new Exception("Endpoint is empty");
+        }
+        if (deepResearchModel == null || deepResearchModel.isEmpty()) {
+            deepResearchModel = chatModel;
+        }
+        if (analysisModel == null || analysisModel.isEmpty()) {
+            analysisModel = chatModel;
+        }
+    }
+
+    private static String trim(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public interface ConfigProvider {
+        String get(String... keys);
+    }
+}


### PR DESCRIPTION
## Summary
- add `JwtOptions`, `GithubOptions`, `DocumentOptions`, and `OpenAIOptions` in Java

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6853e35bbafc8327b0c9e1c6c09b7f28